### PR TITLE
deleted duplicate supportUrl key

### DIFF
--- a/templates/viz/src/manifest.json
+++ b/templates/viz/src/manifest.json
@@ -8,7 +8,6 @@
   "privacyPolicyUrl": "https://url",
   "termsOfServiceUrl": "https://url",
   "packageUrl": "https://url",
-  "supportUrl": "https://url",
   "devMode": "DEVMODE_BOOL",
   "components": [
     {


### PR DESCRIPTION
This hasn't caused problems in Data Studio, but will fail validation with the newest version of dscc-scripts